### PR TITLE
Fix `Invalid import path` when running `apig gen` on Windows

### DIFF
--- a/apig/import.go
+++ b/apig/import.go
@@ -9,7 +9,7 @@ func formatImportDir(paths []string) []string {
 	results := make([]string, 0, len(paths))
 	flag := map[string]bool{}
 	for i := 0; i < len(paths); i++ {
-		dir := filepath.Dir(paths[i])
+		dir := filepath.ToSlash(filepath.Dir(paths[i]))
 		if !flag[dir] && dir != "." {
 			flag[dir] = true
 			results = append(results, dir)
@@ -21,7 +21,7 @@ func formatImportDir(paths []string) []string {
 		//we can find one that matches the current path
 		for _, ipath := range paths {
 			if strings.Index(ipath, "/db") > 0 {
-				return []string{filepath.Dir(ipath)}
+				return []string{filepath.ToSlash(filepath.Dir(ipath))}
 			}
 		}
 	}


### PR DESCRIPTION
On Windows `formatImportDir()` returned an import path that contained backslashes instead of forward slashes, since most of the code base assumes import paths only contain forward slashes this resulted in
things blowing up in `Generate()` (`generate.go`). Replacing backslashes with forward slashes in the import path returned from `formatImportDir()` appears to be sufficient to successfully run `api gen`.